### PR TITLE
fix codeowners to reference all files in the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Code owners below will be automatically assigned as automatic PR reviewers:
-@trevorNgo @Kai-Bailey @amrrsharaff @dandua98 @ngkelly3 @SahilTara
+* @trevorNgo @Kai-Bailey @amrrsharaff @dandua98 @ngkelly3 @SahilTara


### PR DESCRIPTION
Left out the "*" so that it will trigger when any pull request occurs