### PR TITLE
Added functionality to do != on an empty string (list of features/pages) for composition queries

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Composition/QueryableProperty.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Composition/QueryableProperty.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Templates.Core.Composition
 
         public bool Compare(QueryNode query)
         {
-            if (string.IsNullOrEmpty(Value) || string.IsNullOrEmpty(query.Value))
+            if (Value == null || string.IsNullOrEmpty(query.Value))
             {
                 return false;
             }


### PR DESCRIPTION
Summary of changes:
- Changes string.IsNullOrEmpty(Value) to Value == null on the return false check. This is because we should still be able to do an equals and notequals check on an empty value as long as the query.Value is not null or empty.

Related issues:
#68