### PR TITLE
Check and maintain original encoding for other merge postactions

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/MergePostAction.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/MergePostAction.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             File.Delete(Config.FilePath);
         }
 
-        private void HandleMismatchedEncodings(string originalFilePath, string otherFilePath, Encoding originalEncoding, Encoding otherEncoding)
+        protected void HandleMismatchedEncodings(string originalFilePath, string otherFilePath, Encoding originalEncoding, Encoding otherEncoding)
         {
             var relativeFilePath = originalFilePath.GetPathRelativeToGenerationParentPath();
             var otherRelativePath = otherFilePath.GetPathRelativeToGenerationParentPath();
@@ -111,7 +111,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             }
         }
 
-        private Encoding GetEncoding(string originalFilePath)
+        protected Encoding GetEncoding(string originalFilePath)
         {
             // Will read the file, and look at the BOM to check the encoding.
             using (var reader = new StreamReader(File.OpenRead(originalFilePath), true))

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/MergeResourceDictionaryPostAction.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/MergeResourceDictionaryPostAction.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
@@ -44,6 +45,16 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                 var mergeRoot = XElement.Load(Config.FilePath);
                 var sourceRoot = XElement.Load(originalFilePath);
 
+                var originalEncoding = GetEncoding(originalFilePath);
+                var otherEncoding = GetEncoding(Config.FilePath);
+
+                if (originalEncoding.EncodingName != otherEncoding.EncodingName
+                    || !Enumerable.SequenceEqual(originalEncoding.GetPreamble(), otherEncoding.GetPreamble()))
+                {
+                    HandleMismatchedEncodings(originalFilePath, Config.FilePath, originalEncoding, otherEncoding);
+                    return;
+                }
+
                 foreach (var node in GetNodesToMerge(mergeRoot))
                 {
                     var sourceNode = sourceRoot.Elements().FirstOrDefault(e => GetKey(e) == GetKey(node));
@@ -70,7 +81,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                     }
                 }
 
-                using (TextWriter writeFile = new StreamWriter(originalFilePath))
+                using (TextWriter writeFile = new StreamWriter(originalFilePath, false, originalEncoding))
                 {
                     var writer = new ResourceDictionaryWriter(writeFile);
                     writer.WriteResourceDictionary(sourceRoot);
@@ -87,7 +98,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             var relPath = originalFilePath.GetPathRelativeToGenerationPath().Replace(@"\", @"/");
             var postactionContent = MergeDictionaryPattern.Replace("{filePath}", relPath);
             var mergeDictionaryName = Path.GetFileNameWithoutExtension(originalFilePath);
-            File.WriteAllText(GenContext.Current.GenerationOutputPath + $"/App${mergeDictionaryName}_gpostaction.xaml", postactionContent);
+            File.WriteAllText(GenContext.Current.GenerationOutputPath + $"/App${mergeDictionaryName}_gpostaction.xaml", postactionContent, Encoding.UTF8);
         }
 
         private static void AddNode(XElement sourceRoot, XElement node)

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/SearchAndReplacePostAction.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/SearchAndReplacePostAction.cs
@@ -37,6 +37,16 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             var source = File.ReadAllLines(originalFilePath).ToList();
             var instructions = File.ReadAllLines(Config.FilePath).ToList();
 
+            var originalEncoding = GetEncoding(originalFilePath);
+            var otherEncoding = GetEncoding(Config.FilePath);
+
+            if (originalEncoding.EncodingName != otherEncoding.EncodingName
+                || !Enumerable.SequenceEqual(originalEncoding.GetPreamble(), otherEncoding.GetPreamble()))
+            {
+                HandleMismatchedEncodings(originalFilePath, Config.FilePath, originalEncoding, otherEncoding);
+                return;
+            }
+
             var search = new List<string>();
             var replace = new List<string>();
 
@@ -64,7 +74,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             var result = string.Join(Environment.NewLine, source);
             result = result.Replace(string.Join(Environment.NewLine, search), string.Join(Environment.NewLine, replace));
 
-            File.WriteAllLines(originalFilePath, result.Split(new[] { Environment.NewLine }, StringSplitOptions.None));
+            File.WriteAllLines(originalFilePath, result.Split(new[] { Environment.NewLine }, StringSplitOptions.None), originalEncoding);
             File.Delete(Config.FilePath);
         }
     }


### PR DESCRIPTION
Check and maintain original encoding for other merge postactions

#70 We need to ensure the encoding is preserved by the engine