### PR TITLE
Added fix for spaces in generated templates

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/Models/Generation/GenerationItem.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/Models/Generation/GenerationItem.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.ComponentModel.DataAnnotations;
+
 using Microsoft.Templates.Core.Gen;
 
 namespace CoreTemplateStudio.Api.Models.Generation
@@ -15,6 +17,6 @@ namespace CoreTemplateStudio.Api.Models.Generation
         [Required]
         public string Name { get; set; }
 
-        public UserSelectionItem ToGenerationItem() => new UserSelectionItem { Name = this.Name, TemplateId = this.TemplateId };
+        public UserSelectionItem ToGenerationItem() => new UserSelectionItem { Name = this.Name.MakeSafeProjectName(), TemplateId = this.TemplateId };
     }
 }


### PR DESCRIPTION
Summary of changes:
- Add underscore between page names. (Make them safe)
Related issues:
#92