### PR TITLE
Create the Environment.SpecialFolder if it doesn't already exist

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Diagnostics/FileHealthWriter.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Diagnostics/FileHealthWriter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Templates.Core.Diagnostics
 
         private FileHealthWriter()
         {
-            _workingFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Configuration.Current.LogFileFolderPath);
+            _workingFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), Configuration.Current.LogFileFolderPath);
 
             InitializeLogFile();
             PurgeOldLogs(_workingFolder, Configuration.Current.DaysToKeepDiagnosticsLogs);

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Locations/TemplatesSynchronization.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Locations/TemplatesSynchronization.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Templates.Core.Locations
 
         private static readonly string FolderName = Configuration.Current.RepositoryFolderName;
 
-        private readonly Lazy<string> _workingFolder = new Lazy<string>(() => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), FolderName));
+        private readonly Lazy<string> _workingFolder = new Lazy<string>(() => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), FolderName));
 
         private readonly TemplatesContent _content;
 
@@ -41,7 +41,6 @@ namespace Microsoft.Templates.Core.Locations
         {
             string currentContentFolder = CodeGen.Instance?.GetCurrentContentSource(source.Id, source.Platform, source.Language);
             _content = new TemplatesContent(WorkingFolder, source.Id, wizardVersion, source, currentContentFolder);
-
             CurrentWizardVersion = wizardVersion;
         }
 


### PR DESCRIPTION
## PR checklist

- Quick summary of changes
Made it so that the Environment.SpecialFolder is created if it doesn't already exist so we don't have stuff put into a folder that is not expected.

- Which issue does this PR relate to?
#116 