### PR TITLE
Added port through command line capabilities

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/Program.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/Program.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace CoreTemplateStudio.Api
 {
@@ -14,8 +16,20 @@ namespace CoreTemplateStudio.Api
             CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .Build();
+
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseConfiguration(configuration)
+                .UseIISIntegration()
                 .UseStartup<Startup>();
+
+            return host;
+        }
     }
 }

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/Properties/launchSettings.json
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/Properties/launchSettings.json
@@ -17,7 +17,7 @@
     },
     "CoreTemplateStudio.Api": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
## PR checklist

- Quick summary of changes
Allowed user to enter port in through command line by doing ./CoreTemplateStudio.Api.exe --urls=http://localhost:{insert portnum here}
- Which issue does this PR relate to?
#123

(The .exe part is only for windows)