### PR TITLE
Explicitly state some dependencies to resolve NU1605

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/CoreTemplateStudio.Core.csproj
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/CoreTemplateStudio.Core.csproj
@@ -13,6 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
     <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="1.0.0-beta2-20170518-234" />
     <PackageReference Include="Microsoft.TemplateEngine.Core" Version="1.0.0-beta2-20170518-234" />


### PR DESCRIPTION
## PR checklist

- Quick summary of changes
Currently dotnet publish will not work due to NU1605. I specify the dependencies explicitly to fix this bug.