### PR TITLE
Update System.Net.Http package version

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/CoreTemplateStudio.Api.csproj
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/CoreTemplateStudio.Api.csproj
@@ -20,8 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/CoreTemplateStudio.Api.csproj
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Api/CoreTemplateStudio.Api.csproj
@@ -26,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/code/test/CoreTemplateStudio.Api.Test/CoreTemplateStudio.Api.Test.csproj
+++ b/code/test/CoreTemplateStudio.Api.Test/CoreTemplateStudio.Api.Test.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />


### PR DESCRIPTION
- Upgrade System.Net.Http to 4.3.2 to CoreTemplateStudio.Api
- Remove unnecessary packages to CoreTemplateStudio.Api and CoreTemplateStudio.Api.Test projects.