### PR TITLE
Issue144 addcasingparameters

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenComposer.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenComposer.cs
@@ -209,8 +209,6 @@ namespace Microsoft.Templates.Core.Gen
 
                 var genInfo = CreateGenInfo(mainGenInfo.Name, targetTemplate, queue, newItemGeneration);
 
-                AddCasingParams(mainGenInfo.Name, targetTemplate, genInfo);
-
                 foreach (var param in mainGenInfo.Parameters)
                 {
                     if (!genInfo.Parameters.ContainsKey(param.Key))
@@ -218,6 +216,8 @@ namespace Microsoft.Templates.Core.Gen
                         genInfo.Parameters.Add(param.Key, param.Value);
                     }
                 }
+
+                AddCasingParams(mainGenInfo.Name, targetTemplate, genInfo);
             }
         }
 
@@ -243,7 +243,7 @@ namespace Microsoft.Templates.Core.Gen
 
         private static void AddCasingParams(string name, ITemplateInfo template, GenInfo genInfo)
         {
-            foreach (var textCasing in template.GetCasingServices())
+            foreach (var textCasing in template.GetTextCasings())
             {
                 var value = textCasing.Key == "sourceName"
                     ? name
@@ -251,7 +251,10 @@ namespace Microsoft.Templates.Core.Gen
 
                 if (!string.IsNullOrEmpty(value))
                 {
-                    genInfo.Parameters.Add(textCasing.ParameterName, textCasing.Transform(value));
+                    if (!genInfo.Parameters.ContainsKey(textCasing.ParameterName))
+                    {
+                        genInfo.Parameters.Add(textCasing.ParameterName, textCasing.Transform(value));
+                    }
                 }
             }
         }

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Templates/ITemplateInfoExtensions.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Templates/ITemplateInfoExtensions.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Templates.Core
                         .ToDictionary(t => t.Key.Replace(TagPrefix + "export.", string.Empty), v => v.Value.DefaultValue);
         }
 
-        public static List<TextCasing> GetCasingServices(this ITemplateInfo ti)
+        public static List<TextCasing> GetTextCasings(this ITemplateInfo ti)
         {
             var result = new List<TextCasing>();
 

--- a/code/test/CoreTemplateStudio.Core.Test/Templates/ITemplateInfoExtensionsTest.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/Templates/ITemplateInfoExtensionsTest.cs
@@ -694,7 +694,7 @@ namespace Microsoft.Templates.Core.Test
             SetUpFixtureForTesting(language);
 
             var target = GetTargetByName("PageTemplate");
-            var result = target.GetCasingServices();
+            var result = target.GetTextCasings();
 
             Assert.Equal(3, result.Count);
             Assert.Contains(result, r => r.Type == CasingType.Kebab);
@@ -709,7 +709,7 @@ namespace Microsoft.Templates.Core.Test
             SetUpFixtureForTesting(language);
 
             var target = GetTargetByName("UnspecifiedTemplate");
-            var result = target.GetCasingServices();
+            var result = target.GetTextCasings();
 
             Assert.Empty(result);
         }


### PR DESCRIPTION
Quick summary of changes
- Add casing params after other params are added to allow definition of casing params on composition templates
Which issue does this PR relate to?
- #144 Allow for multiple Project Names/Item Names with different character casing styles.