### PR TITLE
Merge postaction fixes

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenParams.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenParams.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Templates.Core.Gen
     {
         public const string Username = "wts.userName";
         public const string RootNamespace = "wts.rootNamespace";
+        public const string ItemNamespace = "wts.itemNamespace";
         public const string WizardVersion = "wts.wizardVersion";
         public const string TemplatesVersion = "wts.templatesVersion";
         public const string HomePageName = "wts.homePageName";

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenParams.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenParams.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Templates.Core.Gen
     {
         public const string Username = "wts.userName";
         public const string RootNamespace = "wts.rootNamespace";
-        public const string ItemNamespace = "wts.itemNamespace";
         public const string WizardVersion = "wts.wizardVersion";
         public const string TemplatesVersion = "wts.templatesVersion";
         public const string HomePageName = "wts.homePageName";

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         private const string CSharpComment = "// ";
         private const string VBComment = "' ";
 
-        public static int SafeIndexOf(this IEnumerable<string> source, string item, int skip, bool ignoreEmptyLines = true)
+        public static int SafeIndexOf(this IEnumerable<string> source, string item, int skip)
         {
-            if (ignoreEmptyLines && string.IsNullOrWhiteSpace(item))
+            if (string.IsNullOrWhiteSpace(item))
             {
                 return -1;
             }
@@ -116,11 +116,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                     }
                     else
                     {
-                        if (mergeMode == MergeMode.Remove)
-                        {
-                            removalBuffer.Add(mergeLine.WithLeadingTrivia(diffTrivia));
-                        }
-                        else if (mergeMode == MergeMode.Insert || mergeMode == MergeMode.InsertBefore || mergeLine == string.Empty)
+                        if (mergeMode == MergeMode.Insert || mergeMode == MergeMode.InsertBefore || mergeLine == string.Empty)
                         {
                             if (mergeMode == MergeMode.InsertBefore)
                             {
@@ -128,6 +124,10 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                             }
 
                             insertionBuffer.Add(mergeLine.WithLeadingTrivia(diffTrivia));
+                        }
+                        else if (mergeMode == MergeMode.Remove)
+                        {
+                            removalBuffer.Add(mergeLine.WithLeadingTrivia(diffTrivia));
                         }
                         else if (mergeMode == MergeMode.OptionalContext)
                         {
@@ -236,7 +236,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             {
                 var insertIndex = GetInsertLineIndex(currentLineIndex, lastLineIndex, beforeMode);
 
-                if (insertIndex <= result.Count)
+                if (insertIndex < result.Count)
                 {
                     EnsureNoWhiteLinesNextToBraces(insertionBuffer, result, insertIndex);
 
@@ -254,7 +254,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         {
             if (removalBuffer.Any() && BlockExists(removalBuffer, result, lastLineIndex) && currentLineIndex > -1)
             {
-                var index = result.SafeIndexOf(removalBuffer[0], lastLineIndex, false);
+                var index = result.SafeIndexOf(removalBuffer[0], lastLineIndex);
                 if (index <= currentLineIndex)
                 {
                     result.RemoveRange(index, removalBuffer.Count);

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         private const string CSharpComment = "// ";
         private const string VBComment = "' ";
 
-        public static int SafeIndexOf(this IEnumerable<string> source, string item, int skip)
+        public static int SafeIndexOf(this IEnumerable<string> source, string item, int skip, bool ignoreWhiteLines = true)
         {
-            if (string.IsNullOrWhiteSpace(item))
+            if (string.IsNullOrWhiteSpace(item) && ignoreWhiteLines)
             {
                 return -1;
             }
@@ -236,7 +236,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             {
                 var insertIndex = GetInsertLineIndex(currentLineIndex, lastLineIndex, beforeMode);
 
-                if (insertIndex < result.Count)
+                if (insertIndex <= result.Count)
                 {
                     EnsureNoWhiteLinesNextToBraces(insertionBuffer, result, insertIndex);
 
@@ -254,7 +254,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         {
             if (removalBuffer.Any() && BlockExists(removalBuffer, result, lastLineIndex) && currentLineIndex > -1)
             {
-                var index = result.SafeIndexOf(removalBuffer[0], lastLineIndex);
+                var index = result.SafeIndexOf(removalBuffer[0], lastLineIndex, false);
                 if (index <= currentLineIndex)
                 {
                     result.RemoveRange(index, removalBuffer.Count);

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/Merge/IEnumerableExtensions.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         private const string CSharpComment = "// ";
         private const string VBComment = "' ";
 
-        public static int SafeIndexOf(this IEnumerable<string> source, string item, int skip)
+        public static int SafeIndexOf(this IEnumerable<string> source, string item, int skip, bool ignoreEmptyLines = true)
         {
-            if (string.IsNullOrWhiteSpace(item))
+            if (ignoreEmptyLines && string.IsNullOrWhiteSpace(item))
             {
                 return -1;
             }
@@ -116,7 +116,11 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                     }
                     else
                     {
-                        if (mergeMode == MergeMode.Insert || mergeMode == MergeMode.InsertBefore || mergeLine == string.Empty)
+                        if (mergeMode == MergeMode.Remove)
+                        {
+                            removalBuffer.Add(mergeLine.WithLeadingTrivia(diffTrivia));
+                        }
+                        else if (mergeMode == MergeMode.Insert || mergeMode == MergeMode.InsertBefore || mergeLine == string.Empty)
                         {
                             if (mergeMode == MergeMode.InsertBefore)
                             {
@@ -124,10 +128,6 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
                             }
 
                             insertionBuffer.Add(mergeLine.WithLeadingTrivia(diffTrivia));
-                        }
-                        else if (mergeMode == MergeMode.Remove)
-                        {
-                            removalBuffer.Add(mergeLine.WithLeadingTrivia(diffTrivia));
                         }
                         else if (mergeMode == MergeMode.OptionalContext)
                         {
@@ -236,7 +236,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
             {
                 var insertIndex = GetInsertLineIndex(currentLineIndex, lastLineIndex, beforeMode);
 
-                if (insertIndex < result.Count)
+                if (insertIndex <= result.Count)
                 {
                     EnsureNoWhiteLinesNextToBraces(insertionBuffer, result, insertIndex);
 
@@ -254,7 +254,7 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.Merge
         {
             if (removalBuffer.Any() && BlockExists(removalBuffer, result, lastLineIndex) && currentLineIndex > -1)
             {
-                var index = result.SafeIndexOf(removalBuffer[0], lastLineIndex);
+                var index = result.SafeIndexOf(removalBuffer[0], lastLineIndex, false);
                 if (index <= currentLineIndex)
                 {
                     result.RemoveRange(index, removalBuffer.Count);

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source.cs
@@ -26,9 +26,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace TestData
 {
-
     //THIS COMMENT SHOULD BE REMOVED
-
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source.cs
@@ -26,7 +26,9 @@ using Windows.UI.Xaml.Navigation;
 
 namespace TestData
 {
+
     //THIS COMMENT SHOULD BE REMOVED
+
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/SourceWithOptionalContextLines.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/SourceWithOptionalContextLines.cs
@@ -26,9 +26,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace TestData
 {
-
     //THIS COMMENT SHOULD BE REMOVED
-
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/SourceWithOptionalContextLines.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/SourceWithOptionalContextLines.cs
@@ -26,7 +26,9 @@ using Windows.UI.Xaml.Navigation;
 
 namespace TestData
 {
+
     //THIS COMMENT SHOULD BE REMOVED
+
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expected.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expected.cs
@@ -135,4 +135,3 @@ namespace TestData
         }
     }
 }
-//FINAL COMMENT

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expected.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expected.cs
@@ -135,3 +135,4 @@ namespace TestData
         }
     }
 }
+//New comment

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expected.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expected.cs
@@ -135,3 +135,4 @@ namespace TestData
         }
     }
 }
+//FINAL COMMENT

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedWithOptionalContextLines.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedWithOptionalContextLines.cs
@@ -139,4 +139,3 @@ namespace TestData
         }
     }
 }
-//FINAL COMMENT

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedWithOptionalContextLines.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedWithOptionalContextLines.cs
@@ -139,3 +139,4 @@ namespace TestData
         }
     }
 }
+//FINAL COMMENT

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedWithOptionalContextLines.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedWithOptionalContextLines.cs
@@ -139,3 +139,4 @@ namespace TestData
         }
     }
 }
+//New comment

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedmergeinfo.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedmergeinfo.cs
@@ -70,3 +70,6 @@ namespace TestData
         //End of block
     }
 }
+//Block to be included
+//New comment
+//End of block

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedmergeinfo.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedmergeinfo.cs
@@ -70,3 +70,6 @@ namespace TestData
         //End of block
     }
 }
+//Block to be included
+//FINAL COMMENT
+//End of block

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedmergeinfo.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_expectedmergeinfo.cs
@@ -70,6 +70,3 @@ namespace TestData
         //End of block
     }
 }
-//Block to be included
-//FINAL COMMENT
-//End of block

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_postaction.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_postaction.cs
@@ -10,7 +10,9 @@ using Windows.UI.Xaml.Navigation;
 namespace TestData
 {
 //{--{
+
     //THIS COMMENT SHOULD BE REMOVED
+
 //}--}
     sealed partial class App : Application
     {
@@ -36,12 +38,10 @@ namespace TestData
             //AFTER ONLAUNCHED!!
             //}]}
             Settings.SettingsViewModel.InitAppTheme();
-
             //^^
             //{[{
             //BEFORE END!!
             var s = "";
-
             //}]}
             //{??{
             //This might be there or not
@@ -73,3 +73,6 @@ namespace TestData
         //}]}
     }
 }
+//{[{
+//FINAL COMMENT
+//}]}

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_postaction.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_postaction.cs
@@ -10,9 +10,7 @@ using Windows.UI.Xaml.Navigation;
 namespace TestData
 {
 //{--{
-
     //THIS COMMENT SHOULD BE REMOVED
-
 //}--}
     sealed partial class App : Application
     {
@@ -38,10 +36,12 @@ namespace TestData
             //AFTER ONLAUNCHED!!
             //}]}
             Settings.SettingsViewModel.InitAppTheme();
+
             //^^
             //{[{
             //BEFORE END!!
             var s = "";
+
             //}]}
             //{??{
             //This might be there or not
@@ -73,6 +73,3 @@ namespace TestData
         //}]}
     }
 }
-//{[{
-//FINAL COMMENT
-//}]}

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_postaction.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Merge/Source_postaction.cs
@@ -10,7 +10,9 @@ using Windows.UI.Xaml.Navigation;
 namespace TestData
 {
 //{--{
+
     //THIS COMMENT SHOULD BE REMOVED
+
 //}--}
     sealed partial class App : Application
     {
@@ -73,3 +75,6 @@ namespace TestData
         //}]}
     }
 }
+//{[{
+//New comment
+//}]}

--- a/code/test/CoreTemplateStudio.Core.Test/app.config
+++ b/code/test/CoreTemplateStudio.Core.Test/app.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="xunit.methodDisplay" value="method" />
+  </appSettings>
+</configuration>

--- a/code/test/CoreTemplateStudio.Core.Test/app.config
+++ b/code/test/CoreTemplateStudio.Core.Test/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <appSettings>
-    <add key="xunit.methodDisplay" value="method" />
-  </appSettings>
-</configuration>


### PR DESCRIPTION
Quick summary of changes
- Remove ItemNamespace 
- Merge postaction is not deleting blank lines between MacroStartDelete and MacroEndDelete
- MergePostaction does not allow adding lines after last line of file

Which issue does this PR relate to?
- #155  Remove itemnamespace from generation parameters once 3.1 is released
- #154  Merge postaction is not deleting blank lines between MacroStartDelete and MacroEndDelete 
- #157  MergePostaction does not allow adding lines after last line of file