### PR TITLE
Sort usings and namespaces only on projects/items generated by WTS

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/SortNamespaces/SortImportsPostAction.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/SortNamespaces/SortImportsPostAction.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.SortNamespaces
 {
     public class SortImportsPostAction : SortNamespacesPostAction
     {
+        public SortImportsPostAction(List<string> paths)
+           : base(paths)
+        {
+        }
+
         public override string FilesToSearch => "*.vb";
 
         public override bool SortMethod(List<string> classContent)

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/SortNamespaces/SortNamespacesPostAction.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/SortNamespaces/SortNamespacesPostAction.cs
@@ -14,24 +14,34 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.SortNamespaces
 {
     public abstract class SortNamespacesPostAction : PostAction
     {
+        public SortNamespacesPostAction(List<string> paths)
+        {
+            Paths = paths;
+        }
+
+        public List<string> Paths { get; set; }
+
         public abstract string FilesToSearch { get; }
 
         public abstract bool SortMethod(List<string> classContent);
 
         internal override void ExecuteInternal()
         {
-            var classFiles = Directory
-                .EnumerateFiles(Path.GetDirectoryName(GenContext.Current.GenerationOutputPath), FilesToSearch, SearchOption.AllDirectories)
+            foreach (var path in Paths)
+            {
+                var classFiles = Directory
+                .EnumerateFiles(path, FilesToSearch, SearchOption.AllDirectories)
                 .ToList();
 
-            foreach (var classFile in classFiles)
-            {
-                var fileContent = File.ReadAllLines(classFile).ToList();
-                var sortResult = SortMethod(fileContent);
-
-                if (sortResult)
+                foreach (var classFile in classFiles)
                 {
-                    File.WriteAllLines(classFile, fileContent, Encoding.UTF8);
+                    var fileContent = File.ReadAllLines(classFile).ToList();
+                    var sortResult = SortMethod(fileContent);
+
+                    if (sortResult)
+                    {
+                        File.WriteAllLines(classFile, fileContent, Encoding.UTF8);
+                    }
                 }
             }
         }

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/SortNamespaces/SortUsingsPostAction.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/Catalog/SortNamespaces/SortUsingsPostAction.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Templates.Core.PostActions.Catalog.SortNamespaces
 {
     public class SortUsingsPostAction : SortNamespacesPostAction
     {
+        public SortUsingsPostAction(List<string> paths)
+            : base(paths)
+        {
+        }
+
         public override string FilesToSearch => "*.cs";
 
         public override bool SortMethod(List<string> classContent)

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/NewItemPostActionFactory.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/NewItemPostActionFactory.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-
+using System.IO;
 using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.Templates.Core.Gen;
 using Microsoft.Templates.Core.PostActions.Catalog;
@@ -33,8 +33,11 @@ namespace Microsoft.Templates.Core.PostActions
             var postActions = new List<PostAction>();
 
             AddGlobalMergeActions(postActions, $"*{MergeConfiguration.GlobalExtension}*", false);
-            postActions.Add(new SortUsingsPostAction());
-            postActions.Add(new SortImportsPostAction());
+
+            var paths = new List<string>() { Path.GetDirectoryName(GenContext.Current.GenerationOutputPath) };
+
+            postActions.Add(new SortUsingsPostAction(paths));
+            postActions.Add(new SortImportsPostAction(paths));
 
             return postActions;
         }

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/NewProjectPostActionFactory.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/PostActions/NewProjectPostActionFactory.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-
+using System.IO;
 using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.Templates.Core.Gen;
 using Microsoft.Templates.Core.PostActions.Catalog;
@@ -31,8 +31,15 @@ namespace Microsoft.Templates.Core.PostActions
             var postActions = new List<PostAction>();
 
             AddGlobalMergeActions(postActions, $"*{MergeConfiguration.GlobalExtension}*", true);
-            postActions.Add(new SortUsingsPostAction());
-            postActions.Add(new SortImportsPostAction());
+
+            var paths = new List<string>();
+            foreach (var proj in GenContext.Current.ProjectInfo.Projects)
+            {
+                paths.Add(Path.GetDirectoryName(proj));
+            }
+
+            postActions.Add(new SortUsingsPostAction(paths));
+            postActions.Add(new SortImportsPostAction(paths));
             postActions.Add(new AddContextItemsToSolutionAndProjectPostAction());
             postActions.Add(new SetDefaultSolutionConfigurationPostAction());
 


### PR DESCRIPTION
- Quick summary of changes
Sort usings and namespaces only on projects/items generated by WTS
- Which issue does this PR relate to?
#160 Limit SortUsing and SortNamespaces postactions to WTS projects 