### PR TITLE
Set default version to 0.0.0.0

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/CoreTemplateStudio.Core.csproj
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/CoreTemplateStudio.Core.csproj
@@ -55,7 +55,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\..\TestKey.snk</AssemblyOriginatorKeyFile>
-    <Version>1.0.0.0</Version>
+    <Version>0.0.0.0</Version>
   </PropertyGroup>
 
 

--- a/code/src/Utilities/Properties/AssemblyInfo.cs
+++ b/code/src/Utilities/Properties/AssemblyInfo.cs
@@ -37,4 +37,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/code/test/Utilities.Test/Properties/AssemblyInfo.cs
+++ b/code/test/Utilities.Test/Properties/AssemblyInfo.cs
@@ -21,4 +21,4 @@ using System.Runtime.InteropServices;
 
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]


### PR DESCRIPTION
- Quick summary of changes
WinTS expects version to be 0.0.0.0 for LocalTemplateSource

- Which issue does this PR relate to?
https://github.com/microsoft/WindowsTemplateStudio/issues/3424
