### PR TITLE
Issue213 required sdk

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/Utilities/CliGenShell.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/Utilities/CliGenShell.cs
@@ -136,5 +136,10 @@ namespace Microsoft.Templates.Cli.Utilities
         public override void WriteOutput(string data)
         {
         }
+
+        public override bool IsSdkInstalled(string name)
+        {
+            return false;
+        }
     }
 }

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenComposer.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenComposer.cs
@@ -62,6 +62,14 @@ namespace Microsoft.Templates.Core.Gen
             return genQueue;
         }
 
+        public static IEnumerable<string> GetAllRequiredSdks(UserSelection userSelection)
+        {
+            return Compose(userSelection)
+                    .SelectMany(s => s.Template.GetRequiredSdks())
+                    .Distinct()
+                    .ToList();
+        }
+
         private static void AddProject(UserSelection userSelection, List<GenInfo> genQueue)
         {
             var projectTemplates = GenContext.ToolBox.Repo

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenContext.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenContext.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Templates.Core.Gen
                 foreach (var d in toBeDeleted)
                 {
                     Fs.SafeDeleteDirectory(d.FullName);
-                    if (!d.Parent.GetDirectories().Any())
+                    if (Directory.Exists(d.Parent.FullName) && !d.Parent.GetDirectories().Any())
                     {
                         Fs.SafeDeleteDirectory(d.Parent.FullName);
                     }

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenShell.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Gen/GenShell.cs
@@ -107,5 +107,7 @@ namespace Microsoft.Templates.Core.Gen
         }
 
         public abstract string CreateCertificate(string publisherName);
+
+        public abstract bool IsSdkInstalled(string name);
     }
 }

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Templates/ITemplateInfoExtensions.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Templates/ITemplateInfoExtensions.cs
@@ -457,6 +457,20 @@ namespace Microsoft.Templates.Core
             return result;
         }
 
+        public static List<string> GetRequiredSdks(this ITemplateInfo ti)
+        {
+            var sdks = GetValueFromTag(ti, TagPrefix + "requiredSdks");
+
+            var result = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(sdks))
+            {
+                result.AddRange(sdks.Split(Separator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries));
+            }
+
+            return result;
+        }
+
         private static string GetConfigDir(ITemplateInfo ti)
         {
             CodeGen.Instance.Settings.SettingsLoader.TryGetFileFromIdAndPath(ti.ConfigMountPointId, ti.ConfigPlace, out IFile file, out IMountPoint mountPoint);

--- a/code/test/CoreTemplateStudio.Core.Test/Templates/ITemplateInfoExtensionsTest.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/Templates/ITemplateInfoExtensionsTest.cs
@@ -507,6 +507,29 @@ namespace Microsoft.Templates.Core.Test
 
         [Theory]
         [MemberData(nameof(GetAllLanguages))]
+        public void GetRequiredSdks(string language)
+        {
+            SetUpFixtureForTesting(language);
+
+            var target = GetTargetByName("ProjectTemplate");
+
+            var result = target.GetRequiredSdks().ToList();
+            Assert.NotNull(result);
+
+            Assert.Collection(
+                result,
+                e1 =>
+                {
+                    Assert.Equal("sdk1", e1);
+                },
+                e2 =>
+                {
+                    Assert.Equal("sdk2", e2);
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAllLanguages))]
         public void GetLicenses_unspecified(string language)
         {
             SetUpFixtureForTesting(language);

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Templates/test/ProjectTemplate/.template.config/template.json
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Templates/test/ProjectTemplate/.template.config/template.json
@@ -14,7 +14,8 @@
     "wts.version": "1.0.0",
     "wts.licenses": "[text1](url1)|[text2](url2)",
     "wts.group": "group1",
-    "wts.defaultInstance": "DefaultName"
+    "wts.defaultInstance": "DefaultName",
+    "wts.requiredSdks": "sdk1|sdk2"
   },
   "sourceName": "App_Name",
   "preferNameDirectory": true

--- a/code/test/CoreTemplateStudio.Core.Test/TestData/Templates/test/ProjectTemplateVB/.template.config/template.json
+++ b/code/test/CoreTemplateStudio.Core.Test/TestData/Templates/test/ProjectTemplateVB/.template.config/template.json
@@ -15,7 +15,8 @@
     "wts.version": "1.0.0",
     "wts.licenses": "[text1](url1)|[text2](url2)",
     "wts.group": "group1",
-    "wts.defaultInstance": "DefaultName"
+    "wts.defaultInstance": "DefaultName",
+    "wts.requiredSdks": "sdk1|sdk2"
   },
   "sourceName": "App_Name",
   "preferNameDirectory": true

--- a/code/test/CoreTemplateStudio.Core.Test/TestFakes/TestShell.cs
+++ b/code/test/CoreTemplateStudio.Core.Test/TestFakes/TestShell.cs
@@ -134,5 +134,10 @@ namespace Microsoft.Templates.Core.Test.TestFakes
         public override void WriteOutput(string data)
         {
         }
+
+        public override bool IsSdkInstalled(string name)
+        {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Quick summary of changes
- Adds possibility to define required SDK s on templates 
- Fixes exception when purging temp generation folders in parallel 

Which issue does this PR relate to?
- #213 Add possibility to define required SDKs on templates
- https://github.com/microsoft/WindowsTemplateStudio/issues/3500 Failed build due to error in PurgeTempGenerations