### PR TITLE
Add table with NewProjectGeneration by platform (Uwp vs Wpf) to telemetry service

### DIFF
--- a/code/tools/WtsTelemetry/Helpers/Queries.cs
+++ b/code/tools/WtsTelemetry/Helpers/Queries.cs
@@ -63,5 +63,8 @@ queryTable
         public string EntryPoints => string.Format(DataQuery, year, month, "WtsWizard", "WtsWizardType");
 
         public string Languages => string.Format(DataQuery, year, month, "WtsProjectGen", "WtsLanguage");
+
+        public string Platforms => string.Format(DataQuery, year, month, "WtsProjectGen", "WtsCategory");
+
     }
 }

--- a/code/tools/WtsTelemetry/Models/WinTSData.cs
+++ b/code/tools/WtsTelemetry/Models/WinTSData.cs
@@ -8,6 +8,7 @@ namespace WtsTelemetry.Models
         public WinTSPlatformData Wpf { get; set; }
         public string entryPoint { get; set; }
         public string Language { get; set; }
+        public string Platform { get; set; }
         public int Year { get; set; }
         public int Month { get; set; }
 
@@ -15,6 +16,7 @@ namespace WtsTelemetry.Models
         {
             return new MarkdownBuilder("Windows Template Studio")
                         .AddHeader(Year, Month)
+                        .AddTable("Category", "Type", Platform)
                         .AddTable("Project Type (Uwp)", "Project", Uwp.Project)
                         .AddTable("Project Type (Wpf)", "Project", Wpf.Project)
                         .AddTable("Framework (Uwp)", "Framework Type", Uwp.Frameworks)

--- a/code/tools/WtsTelemetry/Services/ApplicationInsightService.cs
+++ b/code/tools/WtsTelemetry/Services/ApplicationInsightService.cs
@@ -29,6 +29,7 @@ namespace WtsTelemetry.Services
                 Wpf = GetWinTSPlatformData(wpfQueries),
                 entryPoint = GetData(uwpQueries.EntryPoints),
                 Language = GetData(uwpQueries.Languages),
+                Platform = GetData(uwpQueries.Platforms),
                 Year = year,
                 Month = month
             };


### PR DESCRIPTION
## PR checklist

- Quick summary of changes
Add table with NewProjectGeneration by platform (Uwp vs Wpf) to telemetry service
- Which issue does this PR relate to?
#258 Add data on NewProjectGeneration of UWP vs WPF apps to Telemetry Data
