### PR TITLE
Stop the CLI when the number of allowed exceptions is exceeded

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/App.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/App.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Templates.Cli
         private readonly ICommandDispatcher _dispatcher;
         private readonly IMessageService _messageService;
         private readonly Parser _parser;
-        private int _cathExceptionsCounter;
+        private int _catchedExceptionsCounter;
         private const int ExceptionsAllowed = 50;
 
         public App(ICommandDispatcher dispatcher, IMessageService messageService)
@@ -86,7 +86,7 @@ namespace Microsoft.Templates.Cli
                             return Task.FromResult(0);
                         });
 
-                _cathExceptionsCounter = 0;
+                _catchedExceptionsCounter = 0;
 
                 // todo: use async task
                 return exitCode.Result == 0;
@@ -97,8 +97,8 @@ namespace Microsoft.Templates.Cli
                 AppHealth.Current.Exception.TrackAsync(ex, errorMessage).FireAndForget();
                 _messageService.SendError(errorMessage);
 
-                _cathExceptionsCounter++;
-                if (_cathExceptionsCounter == ExceptionsAllowed)
+                _catchedExceptionsCounter++;
+                if (_catchedExceptionsCounter == ExceptionsAllowed)
                 {
                     _messageService.SendError(StringRes.ErrorMaxExceptionAllowed);
                     AppHealth.Current.Error.TrackAsync(StringRes.ErrorMaxExceptionAllowed).FireAndForget();

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/Resources/StringRes.Designer.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/Resources/StringRes.Designer.cs
@@ -179,6 +179,15 @@ namespace Microsoft.Templates.Cli.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error executing commands in CLI. The number of allowed exceptions has been exceeded..
+        /// </summary>
+        public static string ErrorMaxExceptionAllowed {
+            get {
+                return ResourceManager.GetString("ErrorMaxExceptionAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error parsing Command: {0}.
         ///{1}.
         /// </summary>

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/Resources/StringRes.resx
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/Resources/StringRes.resx
@@ -158,6 +158,9 @@
   <data name="ErrorGenerating" xml:space="preserve">
     <value>Error generating. {0}</value>
   </data>
+  <data name="ErrorMaxExceptionAllowed" xml:space="preserve">
+    <value>Error executing commands in CLI. The number of allowed exceptions has been exceeded.</value>
+  </data>
   <data name="ErrorParsingCommand" xml:space="preserve">
     <value>Error parsing Command: {0}.
 {1}</value>


### PR DESCRIPTION
## PR checklist

- Quick summary of changes
  - stop the CLI when the number of allowed exceptions is exceeded 
  - Register in CoreTS log
- Which issue does this PR relate to?
  - #259 - Add circuit breaker to CoreTS CLI to stop cli when exceeding number of consecutive failuresdely?