### PR TITLE
Support "all" tag when get project types

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Templates/TemplatesRepository.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Templates/TemplatesRepository.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Templates.Core
         public IEnumerable<MetadataInfo> GetProjectTypes(UserSelectionContext context)
         {
             var projectTypes = GetSupportedProjectTypes(context);
-            return GetMetadataInfo("projectTypes").Where(m => m.Platform == context.Platform && projectTypes.Contains(m.Name));
+            return GetMetadataInfo("projectTypes").Where(m => m.Platform == context.Platform && (projectTypes.Contains(m.Name) || projectTypes.Contains(All)));
         }
 
         public IEnumerable<MetadataInfo> GetFrontEndFrameworks(UserSelectionContext context)

--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Templates/TemplatesRepository.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Core/Templates/TemplatesRepository.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Templates.Core
         {
             var filtered = GetAll()
                           .Where(t => t.GetTemplateType() == TemplateType.Project
-                          && t.GetProjectTypeList().Contains(context.ProjectType)
+                          && (t.GetProjectTypeList().Contains(context.ProjectType) || t.GetProjectTypeList().Contains(All))
                           && IsMatchPropertyBag(t, context.PropertyBag)
                           && t.GetPlatform().Equals(context.Platform, StringComparison.OrdinalIgnoreCase)).ToList();
 


### PR DESCRIPTION
## PR checklist

- Quick summary of changes
  - Support "all" tag when get project types
- Which issue does this PR relate to?
  - #279 - Bug: Defining all in project wts.projecttypes does not return any projecttypes