### PR TITLE
Keep track of inner exceptions

### DIFF
--- a/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/Services/SyncService.cs
+++ b/code/src/CoreTemplateStudio/CoreTemplateStudio.Cli/Services/SyncService.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Templates.Cli.Services
             }
             catch (Exception ex)
             {
-                throw new Exception(string.Format(StringRes.ErrorSyncingTemplates, ex.Message));
+                throw new Exception(string.Format(StringRes.ErrorSyncingTemplates, ex.Message), ex);
             }
         }
 


### PR DESCRIPTION
I use this to ship templates for few products. When more than one products are installed this throws:
`Error syncing templates. Error synchronizing templates. No content folder available.`
Now the message is fine, but the inner stack is lost. Please wrap the inner exceptions when bubbling up to higher levels of abstraction or to user facing exceptions.
